### PR TITLE
Adds targets for VS 2017

### DIFF
--- a/src/Merge/src/SSDTDevPack.VSPackage/source.extension.vsixmanifest
+++ b/src/Merge/src/SSDTDevPack.VSPackage/source.extension.vsixmanifest
@@ -11,6 +11,8 @@
   </Metadata>
   <Installation InstalledByMsi="false">
     <InstallationTarget Version="[12.0,14.0]" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
I took the time to fork the repository and add the new targets, but I can't build the thing because I'm in DLL-Nuget Hell with the following error:

> Project: SSDTDevPack.Common
> Unknown build error, 'Cannot resolve dependency to assembly 'Microsoft.Data.Tools.Schema.Sql, Version=13.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' because it has not been preloaded. When using the ReflectionOnly APIs, dependent assemblies must be pre-loaded or loaded on demand through the ReflectionOnlyAssemblyResolve event.'

Any chance you could build this and add it to the release?